### PR TITLE
feat: oSiPaR

### DIFF
--- a/module.py
+++ b/module.py
@@ -10,7 +10,7 @@ class ReversibleRNNFunction(torch.autograd.Function):
         c = torch.bmm(sequence_input, linear_param[0:1, features:].expand(batch, -1, -1))
         a = torch.bmm(b, c)
         o = torch.bmm(a, activate.expand(batch, -1, -1))
-        print((o[0] @ o[0].t())[0, 0].item())
+        o, _ = o.qr()
         return o
 
     @staticmethod

--- a/module.py
+++ b/module.py
@@ -110,7 +110,7 @@ class FixedRevRNN(torch.nn.Module):
 
         self.linear_param0 = torch.nn.Parameter(torch.zeros((depth, 3 * hidden_features, hidden_features)))
         self.linear_param1 = torch.nn.Parameter(torch.zeros((depth, 3 * hidden_features, hidden_features)))
-        self.out_linear = torch.nn.Parameter(torch.randn((1, 3 * hidden_features ** 2, out_features)))
+        self.out_linear = torch.nn.Parameter(torch.randn((1, 2 * hidden_features ** 2, out_features)))
 
         self.register_buffer('hidden_state', torch.zeros(1, 2 * hidden_features, hidden_features))
         self.register_buffer('embedding', torch.ones((input_cases, hidden_features, hidden_features)))

--- a/module.py
+++ b/module.py
@@ -132,7 +132,7 @@ class FixedRevRNN(torch.nn.Module):
         seq += self.delay
         zeros = torch.zeros(1, device=fn_input.device, dtype=fn_input.dtype).expand(batch)
         l0 = torch.stack([torch.cat([slice.qr().Q for slice in self.linear_param0[depth].chunk(3, 0)], 0) for depth in range(self.depth)], 0)
-        l0 = torch.stack([torch.cat([slice.qr().Q for slice in self.linear_param1[depth].chunk(3, 0)], 0) for depth in range(self.depth)], 0)
+        l1 = torch.stack([torch.cat([slice.qr().Q for slice in self.linear_param1[depth].chunk(3, 0)], 0) for depth in range(self.depth)], 0)
         fn = ReversibleRNNFunction().apply
         for idx in range(base_seq):
             out = fn(out, fn_input[:, idx], l0, l1, output_list, top, self.depth, self.activation, self.embedding)

--- a/module.py
+++ b/module.py
@@ -112,7 +112,7 @@ class FixedRevRNN(torch.nn.Module):
         self.linear_param1 = torch.nn.Parameter(torch.zeros((depth, 3 * hidden_features, hidden_features)))
         self.out_linear = torch.nn.Parameter(torch.randn((1, 3 * hidden_features ** 2, out_features)))
 
-        self.register_buffer('hidden_state', torch.zeros(1, 3 * hidden_features, hidden_features))
+        self.register_buffer('hidden_state', torch.zeros(1, 2 * hidden_features, hidden_features))
         self.register_buffer('embedding', torch.ones((input_cases, hidden_features, hidden_features)))
 
         for idx in range(depth):

--- a/module.py
+++ b/module.py
@@ -3,44 +3,49 @@ import torch
 
 class ReversibleRNNFunction(torch.autograd.Function):
     @staticmethod
-    def _single_calc(fn_input, sequence_input, linear_param):
-        features = out.size(1)
-        out = torch.bmm(out, linear_param[:features]) + torch.bmm(sequence_input, linear_param[features:])
-        return torch.nn.functional.relu(out) / 2
+    def _single_calc(fn_input, sequence_input, linear_param, activate):
+        features = fn_input.size(2)
+        batch = fn_input.size(0)
+        b = torch.bmm(fn_input, linear_param[0:1, :features].expand(batch, -1, -1))
+        c = torch.bmm(sequence_input, linear_param[0:1, features:].expand(batch, -1, -1))
+        a = torch.bmm(b,c)
+        return torch.bmm(a,activate.expand(batch, -1, -1))
 
     @staticmethod
-    def _calc(fn_input, sequence_input, linear_param, depth):
+    def _calc(fn_input, sequence_input, linear_param, depth, activate):
         out = fn_input
         for idx in range(depth):
-            out = ReversibleRNNFunction._single_calc(out, sequence_input, linear_param[idx])
+            out = ReversibleRNNFunction._single_calc(out, sequence_input, linear_param[idx:idx + 1], activate)
         return out
-b
+
     @staticmethod
-    def _forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth):
+    def _forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth, activate):
         inp = fn_input.chunk(2, 1)
         outputs = [None, None]
-        outputs[1] = (inp[1] + ReversibleRNNFunction._calc(inp[0], sequence_input, linear_param0, depth)) / 2
-        outputs[0] = (inp[0] + ReversibleRNNFunction._calc(outputs[1], sequence_input, linear_param1, depth)) / 2
+        outputs[1] = inp[1] @ ReversibleRNNFunction._calc(inp[0], sequence_input, linear_param0, depth, activate)
+        outputs[0] = inp[0] @ ReversibleRNNFunction._calc(outputs[1], sequence_input, linear_param1, depth, activate)
         out = torch.cat(outputs, 1)
         return out
 
     @staticmethod
-    def _backward_one(out, inp, sequence_input, linear_param, depth):
-        tmp0 = ReversibleRNNFunction._calc(inp, sequence_input, linear_param, depth)
+    def _backward_one(out, inp, sequence_input, linear_param, depth, activate):
+        tmp0 = ReversibleRNNFunction._calc(inp, sequence_input, linear_param, depth, activate)
         return out - tmp0
 
     @staticmethod
-    def forward(ctx, fn_input, _sequence_input, linear_param0, linear_param1, output_list, top, pos_enc, depth):
-        ctx.save_for_backward(_sequence_input, linear_param0, linear_param1, pos_enc)
+    def forward(ctx, fn_input, sequence_input, linear_param0, linear_param1, output_list, top, depth,
+                activate, embedding):
+        ctx.save_for_backward(sequence_input, linear_param0, linear_param1, activate, embedding)
+        sequence_input = embedding[sequence_input]
         ctx.output_list = output_list
         ctx.top = top
         ctx.depth = depth
 
-        sequence_input = torch.cat([_sequence_input, pos_enc], -1)
         if output_list:
             output_list.clear()
         with torch.no_grad():
-            out = ReversibleRNNFunction._forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth)
+            out = ReversibleRNNFunction._forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth,
+                                                      activate)
         with torch.enable_grad():
             out.requires_grad_(True)
             output_list.append(out)
@@ -48,27 +53,26 @@ b
 
     @staticmethod
     def backward(ctx, grad_output):
-        _sequence_input, linear_param0, linear_param1, pos_enc = ctx.saved_tensors
+        sequence_input, linear_param0, linear_param1, activate, embedding = ctx.saved_tensors
+        sequence_input = embedding[sequence_input]
         depth = ctx.depth
-        sequence_input = torch.cat([_sequence_input, pos_enc], -1)
-        sequence_input.requires_grad_(_sequence_input.requires_grad)
         if not sequence_input.requires_grad:
             return (None,) * 8
         out = ctx.output_list.pop(0)
         features = out.size(1) // 2
         out0, out1 = out[:, :features], out[:, features:]
         with torch.no_grad():
-            inp0 = ReversibleRNNFunction._backward_one(out0, out1, sequence_input, linear_param1, depth)
-            inp1 = ReversibleRNNFunction._backward_one(out1, inp0, sequence_input, linear_param0, depth)
+            inp0 = ReversibleRNNFunction._backward_one(out0, out1, sequence_input, linear_param1, depth, activate)
+            inp1 = ReversibleRNNFunction._backward_one(out1, inp0, sequence_input, linear_param0, depth, activate)
         with torch.enable_grad():
             fn_input = torch.cat([inp0, inp1], 1)
             fn_input.detach_()
             fn_input.requires_grad_(True)
-            args = (fn_input, sequence_input, linear_param0, linear_param1, depth)
+            args = (fn_input, sequence_input, linear_param0, linear_param1, depth, activate)
             grad_out = ReversibleRNNFunction._forward_pass(*args)
         grad_out.requires_grad_(True)
-        grad_out = torch.autograd.grad(grad_out, (fn_input, _sequence_input, linear_param0, linear_param1), grad_output,
-                                       allow_unused=True)
+        grad_out = torch.autograd.grad(grad_out, (fn_input, sequence_input, linear_param0, linear_param1, activate),
+                                       grad_output, allow_unused=True)
         fn_input.detach_()
         fn_input.requires_grad_(True)
         if not ctx.top:
@@ -76,131 +80,70 @@ b
         return grad_out + (None,) * 4
 
 
-class AdaptiveRevRNN(torch.nn.Module):
-    def __init__(self, input_features, hidden_features, return_sequences=False, delay=8, depth=1):
-        super(AdaptiveRevRNN, self).__init__()
-        if hidden_features % 2:
-            raise UserWarning(f"Ignoring uneven hidden feature and proceeding as if equal {hidden_features // 2 * 2}")
-
-        self.return_sequences = return_sequences
-        self.delay = delay
-        self.input_features = input_features
-
-        hidden_features = hidden_features // 2
-        input_features += 2
-
-        self.hidden_state = torch.nn.Parameter(torch.zeros(hidden_features * 2))
-        torch.nn.init.normal_(self.hidden_state)
-
-        self.linear_param0 = torch.nn.Parameter(torch.zeros((depth,
-                                                             input_features + hidden_features,
-                                                             2 * hidden_features)))
-        self.linear_param1 = torch.nn.Parameter(torch.zeros((depth,
-                                                             input_features + hidden_features,
-                                                             2 * hidden_features)))
-
-        for idx in range(depth):
-            torch.nn.init.orthogonal_(self.linear_param0[idx])
-            torch.nn.init.orthogonal_(self.linear_param1[idx])
-
-        self.depth = depth
-
-    def _apply_forward(self, itm, out, output_list, function_output, top, pos_enc):
-        out = ReversibleRNNFunction.apply(out, itm, self.linear_param0, self.linear_param1, output_list, top, pos_enc,
-                                          self.depth)
-        if self.return_sequences:
-            function_output.append(out)
-        return out
-
-    def forward(self, fn_input: torch.Tensor):
-        output_list = []
-        batch, seq, _ = fn_input.size()
-        out = self.hidden_state.view(1, -1).expand(batch, -1)
-        out.requires_grad_(fn_input.requires_grad)
-        input_features = self.input_features
-        output = []
-        top = True
-        base_seq = seq
-        seq += self.delay
-        zeros = torch.zeros((1, 1), device=fn_input.device, dtype=fn_input.dtype).expand(batch, input_features)
-        factor = (seq + 1) / 2
-        indices = torch.arange(1, seq + 1, dtype=fn_input.dtype, device=fn_input.device).view(1, -1, 1)
-        positional_encoding = torch.cat([indices, (indices - factor) / factor], -1).expand(batch, -1, -1).to(
-            fn_input.dtype)
-        for idx in range(base_seq):
-            out = self._apply_forward(fn_input[:, idx], out, output_list, output, top, positional_encoding[:, idx])
-            top = False
-        for idx in range(base_seq, seq):
-            out = self._apply_forward(zeros, out, output_list, output, top, positional_encoding[:, idx])
-            top = False
-        if self.return_sequences:
-            out = torch.stack(output[self.delay:], 1)
-        return out
-
-
 class FixedRevRNN(torch.nn.Module):
-    def __init__(self, input_features, hidden_features, out_features, return_sequences=False, delay=8, depth=1, input_count=0):
+    def __init__(self, input_cases, hidden_features, out_features, return_sequences=False, delay=8, depth=1,
+                 input_count=0):
         super(FixedRevRNN, self).__init__()
         if input_count <= 0:
             raise UserWarning("No input count given")
         if hidden_features % 2:
             raise UserWarning(f"Ignoring uneven hidden feature and proceeding as if equal {hidden_features // 2 * 2}")
-        if input_features != hidden_features:
-            raise ValueError(f"Make sure the orthogonal input features have the same dimensionality as the hidden features")
 
         self.return_sequences = return_sequences
         self.delay = delay
-        self.input_features = input_features
+        self.hidden_features = hidden_features
         self.input_count = input_count
 
         hidden_features = hidden_features // 2
-        input_features += 2
 
-        self.hidden_state = torch.nn.Parameter(torch.zeros(hidden_features * 2))
-        torch.nn.init.normal_(self.hidden_state)
+        self.hidden_state = torch.nn.Parameter(torch.zeros(2*hidden_features, hidden_features))
+        self.hidden_state.data = self.hidden_state.data.unsqueeze(0)
 
         self.linear_param0 = torch.nn.Parameter(torch.zeros((depth,
                                                              2 * hidden_features,
                                                              hidden_features)))
         self.linear_param1 = torch.nn.Parameter(torch.zeros((depth,
-                                                             input_features + hidden_features,
+                                                             2 * hidden_features,
                                                              hidden_features)))
         self.out_linear = torch.nn.Parameter(torch.randn((1, 2 * hidden_features, out_features)))
+        self.register_buffer('activation', torch.ones((hidden_features, hidden_features)).qr()[0].unsqueeze(0))
+        self.register_buffer('embedding', torch.ones((input_cases, hidden_features, hidden_features)))
 
         for idx in range(depth):
-            torch.nn.init.orthogonal_(self.linear_param0[idx][:hidden_features])
-            torch.nn.init.orthogonal_(self.linear_param0[idx][hidden_features:])
-            torch.nn.init.orthogonal_(self.linear_param1[idx][:hidden_features])
-            torch.nn.init.orthogonal_(self.linear_param1[idx][hidden_features:])
+            for sub_idx in range(2):
+                torch.nn.init.orthogonal_(self.linear_param0[idx][sub_idx*hidden_features:(1+sub_idx)*hidden_features])
+                torch.nn.init.orthogonal_(self.linear_param1[idx][sub_idx*hidden_features:(1+sub_idx)*hidden_features])
+
+        for idx in range(input_cases):
+            torch.nn.init.orthogonal_(self.embedding[idx])
+
+        torch.nn.init.orthogonal_(self.hidden_state[0][:hidden_features])
+        torch.nn.init.orthogonal_(self.hidden_state[0][hidden_features:])
+
 
         self.depth = depth
-
-    def _apply_forward(self, itm, out, output_list, function_output, top, pos_enc):
-        return out
 
     def forward(self, fn_input: torch.Tensor):
         # B, S, F, F
         output_list = []
         batch = fn_input.size(0)
-        out = self.hidden_state.view(1, -1).expand(batch, -1)
-        out.requires_grad_(fn_input.requires_grad)
-        input_features = self.input_features
+        out = self.hidden_state.expand(batch, -1, -1)
+        out.requires_grad_(True)
+        input_features = self.hidden_features
         output = []
         top = True
         base_seq = seq = self.input_count
         seq += self.delay
-        zeros = torch.eye(input_features, device=fn_input.device, dtype=fn_input.dtype).unsqueeze(0).expand(batch, -1, -1)
-        factor = (seq + 1) / 2
-        indices = torch.arange(1, seq + 1, dtype=fn_input.dtype, device=fn_input.device).view(1, -1, 1)
-        positional_encoding = torch.cat([indices, (indices - factor) / factor], -1).expand(batch, -1, -1)
+        zeros = torch.eye(input_features, device=fn_input.device,
+                          dtype=fn_input.dtype).unsqueeze(0).expand(batch, -1, -1)
         for idx in range(base_seq):
-            out = ReversibleRNNFunction.apply(out, fn_input[:, idx], self.linear_param0, self.linear_param1, 
-                                              output_list, top, positional_encoding[:, idx], self.depth)
+            out = ReversibleRNNFunction.apply(out, fn_input[:, idx], self.linear_param0, self.linear_param1,
+                                              output_list, top, self.depth, self.activation, self.embedding)
             output.append(out)
             top = False
         for idx in range(base_seq, seq):
-            out = ReversibleRNNFunction.apply(out, zeros, self.linear_param0, self.linear_param1, 
-                                              output_list, top, positional_encoding[:, idx], self.depth)
+            out = ReversibleRNNFunction.apply(out, zeros, self.linear_param0, self.linear_param1,
+                                              output_list, top, self.depth, self.activation, self.embedding)
             output.append(out)
             top = False
         out = torch.cat(output[self.delay:], 0)

--- a/module.py
+++ b/module.py
@@ -9,7 +9,7 @@ class ReversibleRNNFunction(torch.autograd.Function):
         b = torch.bmm(fn_input, linear_param[0:1, :features].expand(batch, -1, -1))
         c = torch.bmm(sequence_input, linear_param[0:1, features:].expand(batch, -1, -1))
         a = torch.bmm(b, c)
-        o = torch.bmm(a, activate.expand(batch, -1, -1))
+        o = a.clamp(min=0) # torch.bmm(a, activate.expand(batch, -1, -1))
         o, _ = o.qr()
         return o
 

--- a/module.py
+++ b/module.py
@@ -5,7 +5,7 @@ def _activate_norm(fn_input: torch.Tensor) -> torch.Tensor:
     return torch.nn.functional.relu(torch.nn.functional.instance_norm(fn_input))
 
 
-def _single_calc(self, fn_input, sequence_input, linear_param):
+def _single_calc(fn_input, sequence_input, linear_param):
     features = fn_input.size(2)
     batch = fn_input.size(0)
     fn_input = _activate_norm(fn_input)
@@ -16,14 +16,14 @@ def _single_calc(self, fn_input, sequence_input, linear_param):
     return o.qr().Q
 
 
-def _calc(self, fn_input, sequence_input, linear_param, depth):
+def _calc(fn_input, sequence_input, linear_param, depth):
     out = fn_input
     for idx in range(depth):
         out = _single_calc(out, sequence_input, linear_param[idx:idx + 1])
     return out
 
 
-def _forward_pass(self, fn_input, sequence_input, linear_param0, linear_param1, depth):
+def _forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth):
     inp = fn_input.chunk(2, 1)
     outputs = [None, None]
     outputs[1] = torch.bmm(inp[1], _calc(inp[0], sequence_input, linear_param0, depth))
@@ -32,7 +32,7 @@ def _forward_pass(self, fn_input, sequence_input, linear_param0, linear_param1, 
     return out
 
 
-def _backward_one(self, out, inp, sequence_input, linear_param, depth):
+def _backward_one(out, inp, sequence_input, linear_param, depth):
     return torch.bmm(out, _calc(inp, sequence_input, linear_param, depth).transpose(1, 2))
 
 

--- a/module.py
+++ b/module.py
@@ -2,28 +2,32 @@ import torch
 
 
 def _activate_norm(fn_input: torch.Tensor) -> torch.Tensor:
-    return torch.nn.functional.relu(torch.nn.functional.instance_norm(fn_input))
+    return torch.nn.functional.relu(fn_input)
 
 
 def _single_calc(fn_input, sequence_input, linear_param):
-    features = fn_input.size(2)
+    features_sqrt = fn_input.size(2)
     batch = fn_input.size(0)
+    features = features_sqrt ** 2
+    fn_input = fn_input.view(batch, features)
     fn_input = _activate_norm(fn_input)
-    b = torch.bmm(fn_input, linear_param[0:1, :features].expand(batch, -1, -1))
-    c = torch.bmm(sequence_input, linear_param[0:1, features:features * 2].expand(batch, -1, -1))
-    o = _activate_norm((b * c))
-    o = torch.bmm(o, linear_param[0:1, features * 2:].expand(batch, -1, -1))
+    b = torch.mm(fn_input, linear_param[:features])
+    c = torch.mm(sequence_input, linear_param[features:features * 2])
+    o = _activate_norm(b * c)
+    o = torch.mm(o, linear_param[features * 2:])
+    o = o.view(batch, features_sqrt, features_sqrt)
     return o.qr().Q
 
 
-def _calc(fn_input, sequence_input, linear_param, depth):
+def _calc(fn_input: torch.Tensor, sequence_input: torch.Tensor, linear_param: torch.Tensor, depth: int):
     out = fn_input
     for idx in range(depth):
-        out = _single_calc(out, sequence_input, linear_param[idx:idx + 1])
+        out = _single_calc(out, sequence_input, linear_param[idx])
     return out
 
 
-def _forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth):
+def _forward_pass(fn_input: torch.Tensor, sequence_input: torch.Tensor, linear_param0: torch.Tensor,
+                  linear_param1: torch.Tensor, depth: int):
     inp = fn_input.chunk(2, 1)
     outputs = [None, None]
     outputs[1] = torch.bmm(inp[1], _calc(inp[0], sequence_input, linear_param0, depth))
@@ -32,11 +36,12 @@ def _forward_pass(fn_input, sequence_input, linear_param0, linear_param1, depth)
     return out
 
 
-def _backward_one(out, inp, sequence_input, linear_param, depth):
+def _backward_one(out: torch.Tensor, inp: torch.Tensor, sequence_input: torch.Tensor, linear_param: torch.Tensor,
+                  depth: int):
     return torch.bmm(out, _calc(inp, sequence_input, linear_param, depth).transpose(1, 2))
 
 
-class ReversibleRNNFunction(torch.autograd.Function): 
+class ReversibleRNNFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, fn_input, sequence_input, linear_param0, linear_param1, output_list, top, depth, embedding):
         ctx.save_for_backward(sequence_input, linear_param0, linear_param1, embedding)
@@ -53,7 +58,7 @@ class ReversibleRNNFunction(torch.autograd.Function):
             out.requires_grad_(True)
             output_list.append(out)
             return out
-        
+
     @staticmethod
     def backward(ctx, grad_output):
         sequence_input, linear_param0, linear_param1, embedding = ctx.saved_tensors
@@ -75,7 +80,8 @@ class ReversibleRNNFunction(torch.autograd.Function):
             args = (fn_input, sequence_input, linear_param0, linear_param1, depth)
             grad_out = _forward_pass(*args)
         grad_out.requires_grad_(True)
-        grad_out = torch.autograd.grad(grad_out, (fn_input, sequence_input, linear_param0, linear_param1), grad_output, allow_unused=True)
+        grad_out = torch.autograd.grad(grad_out, (fn_input, sequence_input, linear_param0, linear_param1), grad_output,
+                                       allow_unused=True)
         fn_input.detach_()
         fn_input.requires_grad_(True)
         if not ctx.top:
@@ -84,7 +90,8 @@ class ReversibleRNNFunction(torch.autograd.Function):
 
 
 class FixedRevRNN(torch.nn.Module):
-    def __init__(self, input_cases, hidden_features, out_features, return_sequences=False, delay=8, depth=1, input_count=0):
+    def __init__(self, input_cases, hidden_features, out_features, return_sequences=False, delay=8, depth=1,
+                 input_count=0):
         """
 
         :param input_cases: Input cases/max embedding index (not learned, can be extended)
@@ -98,34 +105,31 @@ class FixedRevRNN(torch.nn.Module):
         super(FixedRevRNN, self).__init__()
         if input_count <= 0:
             raise UserWarning("No input count given")
-        if hidden_features % 2:
-            raise UserWarning(f"Ignoring uneven hidden feature and proceeding as if equal {hidden_features // 2 * 2}")
 
+        hidden_features = hidden_features ** 2
         self.return_sequences = return_sequences
         self.delay = delay
         self.input_count = input_count
 
-        hidden_features = hidden_features // 2
         self.hidden_features = hidden_features
 
+        features_sqrt = int(hidden_features ** 0.5)
         self.linear_param0 = torch.nn.Parameter(torch.zeros((depth, 3 * hidden_features, hidden_features)))
         self.linear_param1 = torch.nn.Parameter(torch.zeros((depth, 3 * hidden_features, hidden_features)))
-        self.out_linear = torch.nn.Parameter(torch.randn((1, 2 * hidden_features ** 2, out_features)))
-
-        self.register_buffer('hidden_state', torch.zeros(1, 2 * hidden_features, hidden_features))
-        self.register_buffer('embedding', torch.ones((input_cases, hidden_features, hidden_features)))
+        self.out_linear = torch.nn.Parameter(torch.randn((1, 2 * hidden_features, out_features)))
+        self.embedding = torch.nn.Parameter(torch.randn((input_cases, hidden_features)).mul(0.004))
 
         for idx in range(depth):
             for sub_idx in range(3):
-                torch.nn.init.orthogonal_(self.linear_param0[idx][sub_idx * hidden_features:(1 + sub_idx) * hidden_features])
-                torch.nn.init.orthogonal_(self.linear_param1[idx][sub_idx * hidden_features:(1 + sub_idx) * hidden_features])
+                torch.nn.init.orthogonal_(
+                    self.linear_param0[idx][sub_idx * hidden_features:(1 + sub_idx) * hidden_features])
+                torch.nn.init.orthogonal_(
+                    self.linear_param1[idx][sub_idx * hidden_features:(1 + sub_idx) * hidden_features])
 
-        for idx in range(input_cases):
-            torch.nn.init.orthogonal_(self.embedding[idx])
-
-        torch.nn.init.orthogonal_(self.hidden_state[0][:hidden_features])
-        torch.nn.init.orthogonal_(self.hidden_state[0][hidden_features:])
-
+        hidden_state = torch.randn(1, 2 * features_sqrt, features_sqrt)
+        hidden_state[0, :features_sqrt] = hidden_state[0, :features_sqrt].qr().Q
+        hidden_state[0, features_sqrt:] = hidden_state[0, features_sqrt:].qr().Q
+        self.register_buffer("hidden_state", hidden_state.clone())
         self.depth = depth
 
     def forward(self, fn_input: torch.Tensor):
@@ -139,15 +143,14 @@ class FixedRevRNN(torch.nn.Module):
         base_seq = seq = self.input_count
         seq += self.delay
         zeros = torch.zeros(1, device=fn_input.device, dtype=fn_input.dtype).expand(batch)
-        l0 = torch.stack([torch.cat([slice.qr().Q for slice in self.linear_param0[depth].chunk(3, 0)], 0) for depth in range(self.depth)], 0)
-        l1 = torch.stack([torch.cat([slice.qr().Q for slice in self.linear_param1[depth].chunk(3, 0)], 0) for depth in range(self.depth)], 0)
         fn = ReversibleRNNFunction().apply
         for idx in range(base_seq):
-            out = fn(out, fn_input[:, idx], l0, l1, output_list, top, self.depth, self.embedding)
+            out = fn(out, fn_input[:, idx], self.linear_param0, self.linear_param1, output_list, top, self.depth,
+                     self.embedding)
             output.append(out)
             top = False
         for idx in range(base_seq, seq):
-            out = fn(out, zeros, l0, l1, output_list, top, self.depth, self.embedding)
+            out = fn(out, zeros, self.linear_param0, self.linear_param1, output_list, top, self.depth, self.embedding)
             output.append(out)
             top = False
         out = torch.stack(output[self.delay:], 1).view(batch, base_seq, -1)

--- a/train.py
+++ b/train.py
@@ -1,14 +1,13 @@
 import time
 
 import torch
-import torch_optimizer
 
 import module
 
 HIDDEN = 64  # hidden units are squared
 DELAY = 1
 BATCH_SIZE = 1
-SEQUENCE_LENGTH = 16
+SEQUENCE_LENGTH = 2048
 DROPOUT_RATE = 0.15
 PRINTERVALL = 4
 DEPTH = 1
@@ -58,9 +57,10 @@ mean_acc = 0
 torch.autograd.set_detect_anomaly(True)
 while True:
     start_time = time.time()
+    src = tensor[batch_index].to(DEVICE)
+    batch_index += BATCH_SIZE
     for i in range(1, 1 + length):
         tgt = tensor[batch_index].to(DEVICE)
-        src = tgt * tgt.bernoulli(p=1 - DROPOUT_RATE)
         out = mod(src.to(DEVICE))
         out.transpose_(1, 2)
         lss = torch.nn.functional.cross_entropy(out, tgt)
@@ -68,7 +68,8 @@ while True:
         opt.step()
         opt.zero_grad()
         curr_loss += lss.item()
-        batch_index += SEQUENCE_LENGTH
+        src = tgt
+        batch_index += BATCH_SIZE
         if i % PRINTERVALL == 0:
             mean_loss += curr_loss
             acc = (tgt == out.argmax(1)).sum().item() / tgt.numel() * 100

--- a/train.py
+++ b/train.py
@@ -1,21 +1,27 @@
 import time
+import math
 
+import numpy as np
 import torch
 
 import module
 
-HIDDEN = 32  # hidden units are squared
+HIDDEN = 64  # hidden units are squared
 DELAY = 0
-BATCH_SIZE = 1
-SEQUENCE_LENGTH = 512
+BATCH_SIZE = 256
+SEQUENCE_LENGTH = 64
 DROPOUT_RATE = 0.15
-PRINTERVALL = 64
+PRINTERVALL = 128
 DEPTH = 1
 DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 DTYPE = torch.double
 
 
 # 3.66 @ 256
+
+def parameter_count(net):
+    parameters = filter(lambda p: p.requires_grad, net.parameters())
+    return sum(np.prod(p.size()) for p in parameters)
 
 def init(module: torch.nn.Module):
     if hasattr(module, "weight") and hasattr(module.weight, "data"):
@@ -36,6 +42,9 @@ mod = torch.nn.Sequential(module.FixedRevRNN(256,
                                              depth=DEPTH,
                                              input_count=SEQUENCE_LENGTH)).to(DEVICE).to(DTYPE)
 mod.apply(init)
+parameters = parameter_count(mod)
+base = int(math.log10(parameters) / 3)
+print(f'Parameters: {parameters/(1000**base):.1f}{" kMBT"[base]}')
 
 tensor = torch.load('out.tensor')
 tensor = tensor.long()
@@ -49,7 +58,8 @@ length = tensor.size(0) // SEQUENCE_LENGTH - 1
 len_len = len(str(length))
 
 mod = torch.jit.trace(mod, tensor[batch_index].to(DEVICE))
-opt = torch.optim.AdamW(mod.parameters(), lr=1e-3, weight_decay=1e-3)
+opt = torch.optim.AdamW(mod.parameters(), lr=0.0625, weight_decay=2e-4)
+sch = torch.optim.lr_scheduler.ReduceLROnPlateau(opt, patience=8, factor=0.4)  # 1024
 
 mean_loss = 0
 curr_loss = 0
@@ -74,6 +84,17 @@ while True:
             acc = (tgt == out.argmax(1)).sum().item() / tgt.numel() * 100
             mean_acc += acc
             print(f"[{i:{len_len}d}/{length}] Loss: {curr_loss / PRINTERVALL:7.4f} - Mean: {mean_loss / i:7.4f}"
-                  f" | Acc: {acc:6.2f}% - Mean: {mean_acc / (i / PRINTERVALL):6.2f}%"
+                  f" | Acc: {acc:6.2f}% - Mean: {mean_acc / (i / PRINTERVALL):6.2f}% - LR: {opt.param_groups[0]['lr']:.6f}"
                   f" | Batch/s: {i / (time.time() - start_time):.3f}s")
             curr_loss = 0
+            sch.step(curr_loss)
+
+# seq 1024
+# no lr scheduler: [   8256/1262160] Loss:  5.5985 - Mean:  8.6705 | Acc:   2.93% - Mean:   2.00% | Batch/s: 1.863s
+# lr sched [  9728/631079] Loss:  5.5599 - Mean:  5.6732 | Acc:   2.64% - Mean:   3.19% - LR: 4.096000000000002e-05 | Batch/s: 1
+# seq 64
+# [   10496/10097290] Loss:  5.6123 - Mean:  6.0518 | Acc:   3.12% - Mean:   4.25% - LR: 0.000041 | Batch/s: 24.568s
+# hidden=64
+# [   11008/10097290] Loss:  6.3630 - Mean: 10.2268 | Acc:   0.00% - Mean:   4.60% - LR: 0.000016 | Batch/s: 15.515s
+# relu instead of orthogonal activation
+# [   10880/10097290] Loss:  6.2875 - Mean: 10.2672 | Acc:   6.25% - Mean:   4.80% - LR: 0.000016 | Batch/s: 15.859s

--- a/train.py
+++ b/train.py
@@ -5,16 +5,18 @@ import torch_optimizer
 
 import module
 
-HIDDEN = 1024
-DELAY = 2
-BATCH_SIZE = 64
-SEQUENCE_LENGTH = 2048
+HIDDEN = 64  # hidden units are squared
+DELAY = 1
+BATCH_SIZE = 1
+SEQUENCE_LENGTH = 16
 DROPOUT_RATE = 0.15
 PRINTERVALL = 4
 DEPTH = 1
 DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 DTYPE = torch.double
-#3.66 @ 256
+
+
+# 3.66 @ 256
 
 def init(module: torch.nn.Module):
     if hasattr(module, "weight") and hasattr(module.weight, "data"):
@@ -48,7 +50,7 @@ length = tensor.size(0) // SEQUENCE_LENGTH - 1
 len_len = len(str(length))
 
 mod = torch.jit.trace(mod, tensor[batch_index].to(DEVICE))
-opt = torch_optimizer.RAdam(mod.parameters(), lr=1e-3, weight_decay=1e-3)
+opt = torch.optim.AdamW(mod.parameters(), lr=1e-3, weight_decay=1e-3)
 
 mean_loss = 0
 curr_loss = 0

--- a/train.py
+++ b/train.py
@@ -27,8 +27,7 @@ def init(module: torch.nn.Module):
         torch.nn.init.constant_(module.bias.data, 0)
 
 
-mod = torch.nn.Sequential(torch.nn.Embedding(256, 256),
-                          module.FixedRevRNN(256,
+mod = torch.nn.Sequential(module.FixedRevRNN(256,
                                              HIDDEN,
                                              256,
                                              delay=DELAY,

--- a/train.py
+++ b/train.py
@@ -4,12 +4,12 @@ import torch
 
 import module
 
-HIDDEN = 64  # hidden units are squared
-DELAY = 1
+HIDDEN = 32  # hidden units are squared
+DELAY = 0
 BATCH_SIZE = 1
-SEQUENCE_LENGTH = 2048
+SEQUENCE_LENGTH = 512
 DROPOUT_RATE = 0.15
-PRINTERVALL = 4
+PRINTERVALL = 64
 DEPTH = 1
 DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 DTYPE = torch.double
@@ -57,10 +57,9 @@ mean_acc = 0
 torch.autograd.set_detect_anomaly(True)
 while True:
     start_time = time.time()
-    src = tensor[batch_index].to(DEVICE)
-    batch_index += BATCH_SIZE
     for i in range(1, 1 + length):
-        tgt = tensor[batch_index].to(DEVICE)
+        src = tensor[batch_index].to(DEVICE)
+        tgt = tensor[batch_index + DELAY + 1].to(DEVICE)
         out = mod(src.to(DEVICE))
         out.transpose_(1, 2)
         lss = torch.nn.functional.cross_entropy(out, tgt)
@@ -69,7 +68,7 @@ while True:
         opt.zero_grad()
         curr_loss += lss.item()
         src = tgt
-        batch_index += BATCH_SIZE
+        batch_index += SEQUENCE_LENGTH
         if i % PRINTERVALL == 0:
             mean_loss += curr_loss
             acc = (tgt == out.argmax(1)).sum().item() / tgt.numel() * 100


### PR DESCRIPTION
enforce usage of orthogonal SiPaR. Orthogonality enforces gradient and norm stability but requires minor changes that are incompatible with pytorch's embedding. Therefore a commit with custom zero-cost embedding (fused with SiPaR function -> _no_ memory cost) will be added.