### PR TITLE
WIP: TorchScript/Trace

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -5,13 +5,18 @@ model:
   batch_size: 1024
   feed_forward_intermediate_factor: 0.125
 optimizer:
+  type: Shampoo
   beta2: 0.95
-  gradient_accumulation_steps: 1
+  gradient_accumulation_steps: 4
+  start_preconditioning_step: 32
+  preconditioning_compute_steps: 1
+  matrix_eps: 0.0000000001
   one_cycle:
-    cycle_first_step_size: 8192
+    cycle_first_step_size: 1024
     cycle_second_step_size: null
-    cycle_max_lr: 0.01
+    cycle_min_lr: 0
+    cycle_max_lr: 0.1
 log:
-  loss_steps_per_print: 8
+  loss_steps_per_print: 1
 dataset:
   num_workers: 12

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -14,7 +14,7 @@ optimizer:
   one_cycle:
     cycle_first_step_size: 1024
     cycle_second_step_size: null
-    cycle_min_lr: 0
+    cycle_min_lr: 0.001
     cycle_max_lr: 0.1
 log:
   loss_steps_per_print: 128

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,13 +1,13 @@
 model:
-  depth: 32
+  depth: 4
   conv_kernel_size: 11
   weight_shared_blocks: 1
-  batch_size: 1024
+  batch_size: 512
   feed_forward_intermediate_factor: 0.125
 optimizer:
-  type: Shampoo
+  type: AdamW
   beta2: 0.95
-  gradient_accumulation_steps: 4
+  gradient_accumulation_steps: 1
   start_preconditioning_step: 32
   preconditioning_compute_steps: 1
   matrix_eps: 0.0000000001
@@ -17,6 +17,6 @@ optimizer:
     cycle_min_lr: 0
     cycle_max_lr: 0.1
 log:
-  loss_steps_per_print: 1
+  loss_steps_per_print: 128
 dataset:
   num_workers: 12

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -41,8 +41,12 @@ class Model(DataClass):
     conv_kernel_size: int = 7
     feed_forward_intermediate_factor: float = 2.
     dropout_probability: float = 0.
-    bottleneck_group = 1  # not all group counts are possible. it has to be divide self.features without residual
+    bottleneck_group: int = 1  # not all group counts are possible. it has to be divide self.features without residual
     moe: MoE = MoE()
+    shuffle_groups: int = 1
+    # connect to `features // shuffle_groups` random and deterministically selected channels
+    # shuffle_groups are not applied on MoE, but instead only on convolution. If MoE input and output are enabled,
+    # shuffle_groups are only used in the bottleneck block making it equivalent to bottleneck_group
     offloading: bool = False
 
 
@@ -118,6 +122,7 @@ class Optimizer(DataClass):
     beta2: float = 0.95  # beta1 is controlled by one_cycle
     eps: float = 1e-8
     weight_decay: float = 0.01
+    nesterov: bool = True
     zero: Zero = Zero()
     agc = AdaptiveGradientClipping()
     sharpness_aware_minimization: SharpnessAwareMinimization = SharpnessAwareMinimization()
@@ -132,7 +137,6 @@ class Optimizer(DataClass):
     block_size: int = 128
     best_effort_shape_interpretation: bool = True
     graft_type: str = 'adagrad'  # 'Adagrad' or 'SGD'
-    nesterov: bool = True
     no_preconditioning_for_layers_with_dim_gt: int = 8192
 
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -33,6 +33,9 @@ def get_dataset(ctx: Context) -> torch.utils.data.DataLoader:
         print(f"Warning: prefetch_factor ({ctx.dataset.prefetch_factor}) < num_workers ({ctx.dataset.num_workers})."
               f"Some workers will be idle at all times. Reducing num_workers ({ctx.dataset.num_workers}) to "
               f"prefetch_factor ({ctx.dataset.prefetch_factor}).")
-    return torch.utils.data.DataLoader(Dataset(ctx), 1, True,
+    # * 2 because of sharpness-aware minimization
+    return torch.utils.data.DataLoader(Dataset(ctx), ctx.optimizer.gradient_accumulation_steps * 2, True,
                                        num_workers=min(ctx.dataset.num_workers, ctx.dataset.prefetch_factor),
                                        pin_memory=ctx.dataset.pin_memory, prefetch_factor=ctx.dataset.prefetch_factor)
+
+

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -3,6 +3,7 @@ import wandb
 
 from src.dataclass import Context
 from src.dataset import get_dataset
+from src.model import sorted_weight_values, sorted_weights
 from src.utils.formatting import WandbLog
 from src.utils.setup import get_model
 
@@ -11,46 +12,30 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
     wandb.init(project=ctx.log.wandb.project, entity=ctx.log.wandb.entity, config=ctx.serialize())
     ctx = Context(wandb.config)
 
-    mod = get_model(ctx, load_model)
-    wandb.watch(mod, log=ctx.log.wandb.model_log_type, log_freq=ctx.log.wandb.log_frequency)
-
     data = get_dataset(ctx)
     log = WandbLog(ctx, len(data))
-    mean_loss = torch.zeros([], device=ctx.model.device, dtype=torch.float16 if ctx.model.float16 else torch.float)
+
+    mod, opt, sched = get_model(ctx, load_model)
+    itr = iter(data)
+    mod = torch.jit.trace(mod, next(itr), check_trace=False)
+    wandb.watch(mod, log=ctx.log.wandb.model_log_type, log_freq=ctx.log.wandb.log_frequency)
+
+    mean_loss0 = torch.zeros([], device=ctx.model.device, dtype=torch.float16 if ctx.model.float16 else torch.float)
+    mean_loss1 = torch.zeros([], device=ctx.model.device, dtype=torch.float16 if ctx.model.float16 else torch.float)
 
     i = 0
     while True:
         i += 1
-
-        loss = mod.accumulated_step(data)
-        if ctx.optimizer.sharpness_aware_minimization.enabled:
-            with torch.no_grad():
-                for p in mod.gradients():
-                    if ctx.optimizer.sharpness_aware_minimization.adaptive:
-                        p.grad *= p.square()
-                    p.grad *= ctx.optimizer.sharpness_aware_minimization.step_size
-                    p.add_(p.grad)
-                    p.prev_step = p.grad
-                    p.grad = None
-            loss = mod.accumulated_step(data)
-        mod.optimizer.step()
-        if ctx.optimizer.sharpness_aware_minimization.enabled:
-            with torch.no_grad():
-                for p in mod.gradients():
-                    p.sub_(p.prev_step)
-                    p.prev_step = None
-                    p.grad = None
-        else:
-            mod.zero_grad()
-        mod.scheduler.step()
-        for p in mod.optimizer.param_groups:  # OneCycle resets beta2 to 0.990
-            p['betas'] = p['betas'][0], mod.ctx.optimizer.beta2
-        mean_loss += loss
+        loss0, loss1, weights = mod(*next(itr))
+        mean_loss0 += loss0
+        mean_loss1 += loss1
+        mod.load_state_dict({k: s for s, (k, v) in zip(weights, sorted_weights(mod))})
         with torch.no_grad():
-            if mod.ctx.log.loss_steps_per_print and i % mod.ctx.log.loss_steps_per_print == 0:
-                log(mean_loss, mod.optimizer.param_groups[0]['lr'], mod.optimizer.param_groups[0]['betas'])
-                mean_loss.zero_()
-            if mod.ctx.model.steps_per_checkpoint and i % mod.ctx.model.steps_per_checkpoint == 0:
+            if ctx.log.loss_steps_per_print and i % ctx.log.loss_steps_per_print == 0:
+                log(mean_loss0, mean_loss1, opt.param_groups[0]['lr'], opt.param_groups[0]['betas'])
+                mean_loss0.zero_()
+                mean_loss1.zero_()
+            if ctx.model.steps_per_checkpoint and i % ctx.model.steps_per_checkpoint == 0:
                 mod.save()
         if steps and i > steps:
             return

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -3,7 +3,7 @@ import wandb
 
 from src.dataclass import Context
 from src.dataset import get_dataset
-from src.model import sorted_weight_values, sorted_weights
+from src.model import sorted_weights
 from src.utils.formatting import WandbLog
 from src.utils.setup import get_model
 
@@ -30,6 +30,7 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
         mean_loss0 += loss0
         mean_loss1 += loss1
         mod.load_state_dict({k: s for s, (k, v) in zip(weights, sorted_weights(mod))})
+        sched.step()
         with torch.no_grad():
             if ctx.log.loss_steps_per_print and i % ctx.log.loss_steps_per_print == 0:
                 log(mean_loss0, mean_loss1, opt.param_groups[0]['lr'], opt.param_groups[0]['betas'])

--- a/src/model.py
+++ b/src/model.py
@@ -6,10 +6,8 @@ import revlib
 import torch
 import torch.nn.functional
 import torch.utils.data
-from deepspeed.runtime import lr_schedules
 
 from src.dataclass import Context
-from src.optimizers.build import build_optimizer
 
 QUAD_TENSOR = typing.Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
@@ -95,11 +93,11 @@ def conv_weight(in_features: int, out_features: int, kernel_size: int, groups: i
 
 
 class Trainer(torch.nn.Module):
-    def __init__(self, ctx: Context, model: torch.nn.Module, optimizer:torch.optim.Optimizer, scheduler):
+    def __init__(self, ctx: Context, model: torch.nn.Module, optimizer: torch.optim.Optimizer, scheduler):
         super(Trainer, self).__init__()
         self.ctx = ctx
         self.model = model
-        self.optimizer =optimizer
+        self.optimizer = optimizer
         self.scheduler = scheduler
 
     @torch.no_grad()
@@ -148,7 +146,6 @@ class Trainer(torch.nn.Module):
                 p.grad = None
                 p.detach_()
                 p.requires_grad_()
-        self.scheduler.step()
 
         for p in self.optimizer.param_groups:  # OneCycle resets beta2 to 0.990
             p['betas'] = p['betas'][0], self.ctx.optimizer.beta2

--- a/src/optimizers/build.py
+++ b/src/optimizers/build.py
@@ -8,22 +8,17 @@ from src.dataclass import Context
 from src.optimizers import shampoo
 from src.utils.formatting import pretty_print
 
-OPTIMIZERS = {'shampoo': shampoo.Shampoo}
+OPTIMIZERS = {'Shampoo': shampoo.Shampoo}
 
 
 def build_optimizer(ctx: Context, parameters: typing.Iterable[torch.nn.Parameter]):
-    name = ctx.optimizer.type.lower()
-    if name in OPTIMIZERS:
-        return OPTIMIZERS[name](parameters, ctx.optimizer)
-    try:
-        optm = getattr(torch.optim, name)
-        if torch.optim.Optimizer not in inspect.getmro(optm):
-            raise ValueError("Optimizer must inherit from 'torch.optim.Optimizer'.")
-        params = {'params': parameters}
-        for key in inspect.signature(optm).parameters.keys():
-            if key in ctx.optimizer:
-                params[key] = getattr(ctx.optimizer, key)
-        return optm(**params)
-    except TypeError:
-        pretty_print(f'{name} is not a valid optimizer type.')
-        traceback.print_exc()
+    if ctx.optimizer.type in OPTIMIZERS:
+        return OPTIMIZERS[ctx.optimizer.type](parameters, ctx.optimizer)
+    optm = getattr(torch.optim, ctx.optimizer.type)
+    if torch.optim.Optimizer not in inspect.getmro(optm):
+        raise ValueError("Optimizer must inherit from 'torch.optim.Optimizer'.")
+    params = {'params': parameters}
+    for key in inspect.signature(optm).parameters.keys():
+        if key in ctx.optimizer.serialize():
+            params[key] = getattr(ctx.optimizer, key)
+    return optm(**params)

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -34,33 +34,39 @@ def log(*data, log_locals: bool = False):
 
 class WandbLog:
     def __init__(self, ctx: Context, steps: int):
-        self.mean_loss = 0
+        self.mean_loss0 = 0
+        self.mean_loss1 = 0
         self.start_time = time.time()
         self.ctx = ctx
         self.idx = 0
         self.prev = 0
         self.steps = steps
 
-    def __call__(self, current_loss: torch.Tensor, learning_rate: float, betas: typing.Tuple[float, float]):
+    def __call__(self, current_loss0: torch.Tensor, current_loss1: torch.Tensor, learning_rate: float,
+                 betas: typing.Tuple[float, float]):
         grad_accum = self.ctx.optimizer.gradient_accumulation_steps
-        curr_loss = current_loss.item() / self.ctx.log.loss_steps_per_print / grad_accum
+        curr_loss0 = current_loss0.item() / self.ctx.log.loss_steps_per_print / grad_accum
+        curr_loss1 = current_loss1.item() / self.ctx.log.loss_steps_per_print / grad_accum
         self.idx += 1
-        self.mean_loss = (self.mean_loss * self.prev + curr_loss * self.idx) / (self.prev + self.idx)  # LWMA
+        self.mean_loss0 = (self.mean_loss0 * self.prev + curr_loss0 * self.idx) / (self.prev + self.idx)  # LWMA
+        self.mean_loss1 = (self.mean_loss1 * self.prev + curr_loss1 * self.idx) / (self.prev + self.idx)
         self.prev += self.idx
 
         rate = self.ctx.log.loss_steps_per_print * self.idx / (time.time() - self.start_time)
         tokens_per_day = grad_accum * 3600 * 24 * rate * self.ctx.model.batch_size * self.ctx.model.sequence_length
 
         pretty_print(f"[{self.idx * self.ctx.log.loss_steps_per_print:{len(str(self.steps))}d}/{self.steps}]",
-                     f"Loss: {curr_loss:7.4f} -",
-                     f"Mean: {self.mean_loss:7.4f} |",
+                     f"Loss: {curr_loss1:7.4f} -",
+                     f"Mean: {self.mean_loss1:7.4f} |",
                      f"LR: {learning_rate:.6f} -",
                      f"Beta1: {betas[0]:.3f} -",
                      f"Beta2: {betas[1]:.3f} |",
                      f"Batch/s: {rate:6.3f} -",
                      f"Tokens/day: {tokens_per_day:11,.0f}")
-        wandb.log({"Loss/Current": curr_loss,
-                   "Loss/Mean": self.mean_loss,
+        wandb.log({"Loss/Current": curr_loss1,
+                   "Loss/Mean": self.mean_loss1,
+                   "Loss/Current before ascend": curr_loss0,
+                   "Loss/Mean before ascend": self.mean_loss0,
                    "Speed/Batches per Second": rate,
                    "Speed/Tokens per Day": tokens_per_day,
                    "Optimizer/Learning Rate": learning_rate,


### PR DESCRIPTION
This PR uses torch.jit.trace on the entire step instead of torch.jit.script on small parts of the forward pass, allowing for significantly higher speeds.
The current implementation is roughly 5x as fast:
![image](https://user-images.githubusercontent.com/39779310/132991176-76c0aa1b-476c-4901-a2a4-8b0be37c5ba7.png)
but its updates get wonky after a short while:
![image](https://user-images.githubusercontent.com/39779310/132991179-1e9bdc6a-9f95-4282-985f-8b90ed3f30ed.png)
