### PR TITLE
feat(model): Add FFT, OmniNet, custom DataLoader, Windows-Support

### DIFF
--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,8 +1,8 @@
 model:
-  attention: FFTAttention
+  attention: SelfAttention
   sequence_length: 2048
   omnidirectional: no
-  depth: 16
+  depth: 1
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 8

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -5,7 +5,7 @@ model:
   depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
-  batch_size: 1
+  batch_size: 16
   offloading: yes
   features: 2048
   feed_forward_intermediate_factor: 0.125

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -10,9 +10,9 @@ optimizer:
   beta2: 0.95
   gradient_accumulation_steps: 1
   one_cycle:
-    total_steps: 8192
+    total_steps: 1024
     max_lr: 0.01
 log:
-  loss_steps_per_print: 8
+  loss_steps_per_print: 4
 dataset:
-  num_workers: 12
+  num_workers: 16

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,9 +1,10 @@
 model:
-  depth: 16
+  attention: OmnidirectionalAttention
+  depth: 8
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 1
-  features: 1024
+  features: 2048
   feed_forward_intermediate_factor: 0.125
 optimizer:
   beta2: 0.95

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,5 +1,5 @@
 model:
-  depth: 4
+  depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 8

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -7,14 +7,11 @@ model:
   weight_shared_blocks: 1
   batch_size: 1
   offloading: yes
-  features: 1024
+  features: 2048
   feed_forward_intermediate_factor: 0.125
 optimizer:
   beta2: 0.95
   gradient_accumulation_steps: 1
-  one_cycle:
-    total_steps: 1024000
-    max_lr: 0.01
 log:
   loss_steps_per_print: 4
 dataset:

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,11 +1,11 @@
 model:
-  attention: SqueezeExcitation
+  attention: FFTAttention
   sequence_length: 2048
   omnidirectional: no
   depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
-  batch_size: 16
+  batch_size: 8
   offloading: yes
   features: 2048
   feed_forward_intermediate_factor: 0.125

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,8 +1,8 @@
 model:
-  depth: 32
+  depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
-  batch_size: 1024
+  batch_size: 8
   feed_forward_intermediate_factor: 0.125
 optimizer:
   beta2: 0.95

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,5 +1,5 @@
 model:
-  depth: 16
+  depth: 4
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 8

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,10 +1,12 @@
 model:
   attention: SqueezeExcitation
-  omnidirectional: yes
-  depth: 8
+  sequence_length: 2048
+  omnidirectional: no
+  depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 1
+  offloading: yes
   features: 1024
   feed_forward_intermediate_factor: 0.125
 optimizer:

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,16 +1,17 @@
 model:
-  attention: OmnidirectionalAttention
+  attention: FFTAttention
+  omnidirectional: yes
   depth: 8
   conv_kernel_size: 11
   weight_shared_blocks: 1
   batch_size: 1
-  features: 2048
+  features: 1024
   feed_forward_intermediate_factor: 0.125
 optimizer:
   beta2: 0.95
   gradient_accumulation_steps: 1
   one_cycle:
-    total_steps: 1024
+    total_steps: 1024000
     max_lr: 0.01
 log:
   loss_steps_per_print: 4

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -2,15 +2,15 @@ model:
   depth: 16
   conv_kernel_size: 11
   weight_shared_blocks: 1
-  batch_size: 8
+  batch_size: 1
+  features: 1024
   feed_forward_intermediate_factor: 0.125
 optimizer:
   beta2: 0.95
   gradient_accumulation_steps: 1
   one_cycle:
-    cycle_first_step_size: 8192
-    cycle_second_step_size: null
-    cycle_max_lr: 0.01
+    total_steps: 8192
+    max_lr: 0.01
 log:
   loss_steps_per_print: 8
 dataset:

--- a/configs/small.yaml
+++ b/configs/small.yaml
@@ -1,5 +1,5 @@
 model:
-  attention: FFTAttention
+  attention: SqueezeExcitation
   omnidirectional: yes
   depth: 8
   conv_kernel_size: 11

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -52,7 +52,6 @@ class Dataset(DataClass):
     file_name: str = "out.tensor"
     classes: int = 256
     num_workers: int = 4
-    pin_memory: bool = False
     prefetch_factor: int = 256  # 256 (Prefetch) * 8 (Long) * 2048 (GPT context) * 256 (High Batch) = 1GiB RAM
 
 

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -18,6 +18,7 @@ def serialize(instance: typing.Union[DataClass, typing.Dict[str, typing.Any]]):
 
 
 class Model(DataClass):
+    attention: str = "OmnidirectionalAttention"
     weight_sharing: bool = False
     checkpoint_path: str = "checkpoint.torch"
     steps_per_checkpoint: int = 0  # 0 -> disabled

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -1,7 +1,6 @@
 import pathlib
-import typing
-
 import torch
+import typing
 import yaml
 
 
@@ -24,6 +23,7 @@ class Model(DataClass):
     steps_per_checkpoint: int = 0  # 0 -> disabled
     print_on_init: bool = True
     features: int = 256
+    sum_attention_level: int = 0
     momentumnet_beta: float = 0.99  # The higher this is, the more numerically stable. BUT also lower impact per layer
     depth: int = 64
     batch_size: int = 128

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -19,7 +19,7 @@ def serialize(instance: typing.Union[DataClass, typing.Dict[str, typing.Any]]):
 
 
 class Model(DataClass):
-    attention: str = "OmnidirectionalAttention"
+    attention: str = "FFTAttention"
     weight_sharing: bool = False
     checkpoint_path: str = "checkpoint.torch"
     steps_per_checkpoint: int = 0  # 0 -> disabled
@@ -134,7 +134,7 @@ class Optimizer(DataClass):
     statistics_compute_steps: int = 1
     block_size: int = 128
     best_effort_shape_interpretation: bool = True
-    graft_type: str = 'adagrad'  # 'Adagrad' or 'SGD'
+    graft_type: str = 'SGD'  # 'Adagrad' or 'SGD'
     nesterov: bool = True
     no_preconditioning_for_layers_with_dim_gt: int = 8192
 

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -19,7 +19,7 @@ def serialize(instance: typing.Union[DataClass, typing.Dict[str, typing.Any]]):
 
 
 class Model(DataClass):
-    attention: str = "OmnidirectionalAttention"
+    attention: str = "FFTAttention"
     weight_sharing: bool = False
     checkpoint_path: str = "checkpoint.torch"
     steps_per_checkpoint: int = 0  # 0 -> disabled

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -19,7 +19,7 @@ def serialize(instance: typing.Union[DataClass, typing.Dict[str, typing.Any]]):
 
 
 class Model(DataClass):
-    attention: str = "FFTAttention"
+    attention: str = "OmnidirectionalAttention"
     weight_sharing: bool = False
     checkpoint_path: str = "checkpoint.torch"
     steps_per_checkpoint: int = 0  # 0 -> disabled

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -124,7 +124,7 @@ class Optimizer(DataClass):
     one_cycle: OneCycle = OneCycle()
     beta2: float = 0.95  # beta1 is controlled by one_cycle
     eps: float = 1e-8
-    weight_decay: float = 0.01
+    weight_decay: float = 0.
     zero: Zero = Zero()
     agc = AdaptiveGradientClipping()
     sharpness_aware_minimization: SharpnessAwareMinimization = SharpnessAwareMinimization()

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -53,6 +53,7 @@ class Dataset(DataClass):
     file_name: str = "out.tensor"
     classes: int = 256
     num_workers: int = 4
+    dropout: float = 0.3
     pin_memory: bool = False
     prefetch_factor: int = 256  # 256 (Prefetch) * 8 (Long) * 2048 (GPT context) * 256 (High Batch) = 1GiB RAM
 

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -1,6 +1,7 @@
 import pathlib
-import torch
 import typing
+
+import torch
 import yaml
 
 
@@ -52,6 +53,7 @@ class Dataset(DataClass):
     file_name: str = "out.tensor"
     classes: int = 256
     num_workers: int = 4
+    pin_memory: bool = False
     prefetch_factor: int = 256  # 256 (Prefetch) * 8 (Long) * 2048 (GPT context) * 256 (High Batch) = 1GiB RAM
 
 

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -87,19 +87,19 @@ class Zero(DataClass):
 
 
 class OneCycle(DataClass):
-    cycle_min_lr: float = 3e-4  # Base learning rate used at the start and end of cycle.
-    cycle_max_lr: float = 1e-3  # Learning rate used in the middle of the cycle. Can be smaller than cycle_min_lr
-    decay_lr_rate: float = 1e-4  # Decay rate for learning rate.
-    cycle_first_step_size: int = 2048  # Number of training iterations in the increasing half of a cycle.
-    cycle_second_step_size: typing.Optional[int] = None  # steps in second phase. None -> cycle_first_step_size
-    cycle_first_stair_count: int = 0  # Number of stairs in first phase. 0 means staircase disabled
-    cycle_second_stair_count: typing.Optional[int] = None  # Number of stairs in second phase
-    decay_step_size: int = 2  # Every how many steps to decay lr. 0 -> no decay
-    cycle_momentum: bool = True  # Whether to cycle `momentum` inversely to learning rate.
-    cycle_min_mom: float = 0.8  # Initial momentum which is the lower boundary in the cycle for each parameter group.
-    cycle_max_mom: float = 0.9  # Upper momentum boundaries in the cycle for each parameter group.
-    decay_mom_rate: float = 0  # Decay rate for momentum
-    last_batch_iteration: int = -1  # The index of the last batch. This parameter is used when resuming a training job.
+    max_lr: float = 1e-3
+    total_steps: typing.Optional[int] = 10 ** 3
+    epochs: typing.Optional[int] = None
+    steps_per_epoch: typing.Optional[int] = None
+    pct_start: float = 0.3
+    anneal_strategy: str = 'cos'
+    cycle_momentum: bool = True
+    base_momentum: float = 0.85
+    max_momentum: float = 0.95
+    div_factor: float = 25.
+    final_div_factor: float = 1e4
+    three_phase: bool = False
+    last_epoch: int = -1
 
 
 class AdaptiveGradientClipping(DataClass):

--- a/src/dataclass.py
+++ b/src/dataclass.py
@@ -19,6 +19,7 @@ def serialize(instance: typing.Union[DataClass, typing.Dict[str, typing.Any]]):
 
 
 class Model(DataClass):
+    omnidirectional: bool = False
     attention: str = "FFTAttention"
     weight_sharing: bool = False
     checkpoint_path: str = "checkpoint.torch"
@@ -117,6 +118,8 @@ class SharpnessAwareMinimization(DataClass):
 
 class Optimizer(DataClass):
     type: str = "AdamW"
+    final_step: int = 2 ** 14
+    warmup_end: int = 2 ** 10
     gradient_accumulation_steps: int = 1
     one_cycle: OneCycle = OneCycle()
     beta2: float = 0.95  # beta1 is controlled by one_cycle

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,3 +1,5 @@
+import multiprocessing
+import random
 import typing
 
 import torch
@@ -13,26 +15,46 @@ def get_sample(data: torch.Tensor, batch_index: torch.Tensor, idx: int) -> typin
     return dat[:, :-1], dat[:, 1:]
 
 
-class Dataset(torch.utils.data.Dataset):
-    def __init__(self, ctx: Context):
-        self.data = torch.load(ctx.dataset.file_name)
-        batch_index = torch.arange(0, ctx.model.batch_size).view(-1, 1)
-        item_index = torch.arange(0, ctx.model.sequence_length + 1).view(1, -1)
-        self.batch_index = batch_index + item_index
-        self.length = self.data.size(0) - ctx.model.batch_size * ctx.model.sequence_length
+class Dataset:
+    def __init__(self, ctx: Context, length: int, queue: multiprocessing.Queue):
+        self.length = length
+        self.batch = ctx.optimizer.gradient_accumulation_steps
+        self.queue = queue
 
     def __len__(self):
         return self.length
 
-    def __getitem__(self, idx: int) -> typing.Tuple[torch.Tensor, torch.Tensor]:
-        return get_sample(self.data, self.batch_index, idx)
+    def __iter__(self, idx: int) -> typing.Tuple[torch.Tensor, torch.Tensor]:
+        yield next(self)
+
+    def __next__(self):
+        return self.queue.get()
 
 
-def get_dataset(ctx: Context) -> torch.utils.data.DataLoader:
+def _get_process_fn(ctx: Context, queue: multiprocessing.Queue) -> typing.Tuple[typing.Callable[[int], None], int]:
+    data = torch.load(ctx.dataset.file_name)
+    batch_index = torch.arange(0, ctx.model.batch_size).view(-1, 1)
+    item_index = torch.arange(0, ctx.model.sequence_length + 1).view(1, -1)
+    batch_index = batch_index + item_index
+    length = data.size(0) - ctx.model.batch_size * ctx.model.sequence_length
+
+    def _fn(idx):
+        random.seed(idx)
+        while True:
+            queue.put(get_sample(data, batch_index, random.randint(0, length)))
+
+    return _fn, length
+
+
+def get_dataset(ctx: Context) -> Dataset:
     if ctx.dataset.prefetch_factor < ctx.dataset.num_workers:
         print(f"Warning: prefetch_factor ({ctx.dataset.prefetch_factor}) < num_workers ({ctx.dataset.num_workers})."
               f"Some workers will be idle at all times. Reducing num_workers ({ctx.dataset.num_workers}) to "
               f"prefetch_factor ({ctx.dataset.prefetch_factor}).")
-    return torch.utils.data.DataLoader(Dataset(ctx), ctx.optimizer.gradient_accumulation_steps, True,
-                                       num_workers=min(ctx.dataset.num_workers, ctx.dataset.prefetch_factor),
-                                       pin_memory=ctx.dataset.pin_memory, prefetch_factor=ctx.dataset.prefetch_factor)
+    queue = multiprocessing.Queue(ctx.dataset.prefetch_factor)
+    proc_fn, length = _get_process_fn(ctx, queue)
+    procs = [multiprocessing.Process(target=proc_fn, args=(idx,), daemon=True)
+             for idx in range(min(ctx.dataset.num_workers, ctx.dataset.prefetch_factor))]
+    for p in procs:
+        p.start()
+    return Dataset(ctx, length, queue)

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -13,7 +13,7 @@ def get_sample(data: torch.Tensor, batch_index: torch.Tensor, idx: int,
                drop_probability: float) -> typing.Tuple[torch.Tensor, torch.Tensor]:
     dat = data[batch_index + idx]
     dat = dat.to(dtype=torch.long, non_blocking=True)
-    inp = dat * torch.rand(dat.size(), device=dat.device) > drop_probability
+    inp = dat * (torch.rand(dat.size(), device=dat.device) > drop_probability)
     return inp, dat
 
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -10,10 +10,10 @@ from src.dataclass import Context
 
 @torch.jit.script
 def get_sample(data: torch.Tensor, batch_index: torch.Tensor, idx: int,
-               drop_probability:float) -> typing.Tuple[torch.Tensor, torch.Tensor]:
+               drop_probability: float) -> typing.Tuple[torch.Tensor, torch.Tensor]:
     dat = data[batch_index + idx]
     dat = dat.to(dtype=torch.long, non_blocking=True)
-    inp = dat * torch.rand_like(dat) > drop_probability
+    inp = dat * torch.rand(dat.size(), device=dat.device) > drop_probability
     return inp, dat
 
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -22,12 +22,12 @@ class Dataset:
     def __len__(self):
         return self.length
 
-    def __iter__(self, idx: int) -> typing.Tuple[torch.Tensor, torch.Tensor]:
+    def __iter__(self) -> typing.Tuple[torch.Tensor, torch.Tensor]:
         yield next(self)
 
     def __next__(self):
         items = [self.queue.get() for _ in range(self.ctx.optimizer.gradient_accumulation_steps)]
-        return torch.stack([itm for itm in items], 0)
+        return torch.stack(items, 0)
 
 
 def _process_fn(ctx: Context, queue: multiprocessing.Queue, idx: int, worker_count: int):

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -14,29 +14,32 @@ def get_sample(data: torch.Tensor, batch_index: torch.Tensor, idx: int) -> typin
 
 
 class Dataset(torch.utils.data.Dataset):
+    data: torch.Tensor
+
     def __init__(self, ctx: Context, workers: int):
         self.ctx = ctx
         self.workers = workers
-        self.data = torch.empty((1,))
         data = torch.load(self.ctx.dataset.file_name)
-        self.length = data.size(0) - self.ctx.model.batch_size * self.ctx.model.sequence_length
+        self.offset = self.ctx.model.batch_size * self.ctx.model.sequence_length
+        self.length = data.size(0) - self.offset
 
         batch_index = torch.arange(0, ctx.model.batch_size).view(-1, 1)
         item_index = torch.arange(0, ctx.model.sequence_length + 1).view(1, -1)
         self.batch_index = batch_index + item_index
         self.worker_id: int = 0
-        self.slice_size = self.length // self.workers
+        self.slice_size = data.size(0) // self.workers
 
     def __len__(self):
         return self.length
 
     def __getitem__(self, idx: int) -> typing.Tuple[torch.Tensor, torch.Tensor]:
-        return get_sample(self.data, self.batch_index, idx % self.slice_size)
+        return get_sample(self.data, self.batch_index, idx % (self.slice_size - self.offset))
 
+    @torch.no_grad()
     def set_id(self, worker_id: int):
         self.worker_id = worker_id
-        data = torch.load(self.dataset.file_name)
-        self.data = data[self.slice_size * worker_id: self.slice_size * (worker_id + 1)]
+        data = torch.load(self.ctx.dataset.file_name)
+        self.data = data[self.slice_size * worker_id: self.slice_size * (worker_id + 1)].detach()
 
 
 def get_dataset(ctx: Context) -> torch.utils.data.DataLoader:
@@ -46,7 +49,7 @@ def get_dataset(ctx: Context) -> torch.utils.data.DataLoader:
               f"prefetch_factor ({ctx.dataset.prefetch_factor}).")
     workers = min(ctx.dataset.num_workers, ctx.dataset.prefetch_factor)
     dset = Dataset(ctx, workers)
-    return torch.utils.data.DataLoader(dset, ctx.optimizer.gradient_accumulation_steps, True,
+    return torch.utils.data.DataLoader(dset, ctx.optimizer.gradient_accumulation_steps, False,
                                        num_workers=workers, pin_memory=ctx.dataset.pin_memory,
                                        prefetch_factor=ctx.dataset.prefetch_factor,
                                        worker_init_fn=dset.set_id)

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -61,6 +61,8 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
                     mod.optimizer.param_groups[0]['lr'], mod.optimizer.param_groups[0]['betas'])
                 mean_loss.zero_()
                 mean_max_loss.zero_()
+                mean_acc.zero_()
+                mean_max_acc.zero_()
             if mod.ctx.model.steps_per_checkpoint and i % mod.ctx.model.steps_per_checkpoint == 0:
                 mod.save()
         if steps and i > steps:

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -13,7 +13,9 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
 
     data = get_dataset(ctx)
     data_len = len(data)
-    mod = get_model(ctx, load_model, next(data)[0])
+    data = iter(data)
+    next_data = next(data)[0]
+    mod = get_model(ctx, load_model, next_data)
     wandb.watch(mod, log=ctx.log.wandb.model_log_type, log_freq=ctx.log.wandb.log_frequency)
 
     log = WandbLog(ctx, data_len)

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -13,7 +13,6 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
 
     data = get_dataset(ctx)
     data_len = len(data)
-    data = iter(data)
     next_data = next(data)[0]
     mod = get_model(ctx, load_model, next_data)
     wandb.watch(mod, log=ctx.log.wandb.model_log_type, log_freq=ctx.log.wandb.log_frequency)

--- a/src/executable/train.py
+++ b/src/executable/train.py
@@ -13,7 +13,6 @@ def train_model(ctx: Context, steps=None, load_model: bool = False):
 
     data = get_dataset(ctx)
     data_len = len(data)
-    data = iter(data)
     mod = get_model(ctx, load_model, next(data)[0])
     wandb.watch(mod, log=ctx.log.wandb.model_log_type, log_freq=ctx.log.wandb.log_frequency)
 

--- a/src/model.py
+++ b/src/model.py
@@ -76,7 +76,7 @@ class AuxLoss(torch.autograd.Function):
 
 
 def moe(inp: torch.Tensor, expert_weights: torch.nn.ParameterList, training: bool,
-        jitter_epsilon: float, feature_shuffle: torch.Tensor, groups: int, experts: int) -> torch.Tensor:
+        jitter_epsilon: float, groups: int, experts: int) -> torch.Tensor:
     *expert_weights, gate = expert_weights
     batch, features, sequence = inp.size()
     tokens = batch * sequence
@@ -112,8 +112,6 @@ def moe(inp: torch.Tensor, expert_weights: torch.nn.ParameterList, training: boo
     # permute
     inp = inp.gather(0, expert_permutation.expand_as(inp))
 
-    if feature_shuffle is not None:
-        inp = inp.gather(1, feature_shuffle.view(1, -1).expand_as(inp))
     inp = inp.view(tokens // experts, experts * groups, features // groups)
     if len(expert_weights) == 1:
         inp = expert_matmul(inp, expert_weights[0])
@@ -126,43 +124,20 @@ def moe(inp: torch.Tensor, expert_weights: torch.nn.ParameterList, training: boo
 
 
 def moe_check(inp: torch.Tensor, w: torch.nn.ParameterList, training: bool,
-              jitter_epsilon: float, feature_shuffle: torch.Tensor, groups: int, experts: int) -> torch.Tensor:
+              jitter_epsilon: float, groups: int, experts: int) -> torch.Tensor:
     if experts > 0:
-        return moe(inp, w, training, jitter_epsilon, feature_shuffle, groups, experts)
+        return moe(inp, w, training, jitter_epsilon, groups, experts)
     return conv(inp, w[0], groups, False)
 
 
-def linear_attention(inp: torch.Tensor, divisor: torch.Tensor,
-                     w0: torch.nn.ParameterList,
-                     feature_shuffle0: typing.Optional[torch.Tensor], groups0: int, experts0: int,
-                     w1: torch.Tensor,
-                     w2: torch.nn.ParameterList,
-                     feature_shuffle2: typing.Optional[torch.Tensor], groups2: int, experts2: int,
-                     input_cache: torch.Tensor, cumsum_cache: torch.Tensor, bottleneck_group: int, training: bool,
-                     caching: bool, idx: int, norm_power: int, jitter_epsilon: float
-                     ) -> typing.Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    kernel_size = w1.size(2)
-    pad = True
-    if not training and caching:
-        if idx - 1 > kernel_size and inp.size(2) == 1:
-            pad = False
-            inp = torch.cat([input_cache, inp], -1)
-        input_cache = inp[:, :, -kernel_size + 1:].detach()
-    inp = moe_check(inp, w0, training, jitter_epsilon, feature_shuffle0, groups0, experts0)
-    depth, scale, shift = inp.chunk(3, 1)
-    cum = depth.cumsum(-1)
-    if not training and caching:
-        cum = cum + cumsum_cache
-        scale = scale[:, :, -1:]
-        shift = shift[:, :, -1:]
-        cum = cum[:, :, -1:]
-        if idx - 1 > kernel_size:
-            cumsum_cache = cum.detach()
-    inp = TripleNorm.apply(cum / divisor, scale, shift, norm_power)
-    inp = conv(inp, w1, bottleneck_group, pad)
+def linear_attention(inp: torch.Tensor, w0: torch.nn.ParameterList, groups0: int, experts0: int, w1: torch.Tensor,
+                     w2: torch.nn.ParameterList, groups2: int, experts2: int, bottleneck_group: int, training: bool,
+                     norm_power: int, jitter_epsilon: float) -> torch.Tensor:
+    inp = moe_check(inp, w0, training, jitter_epsilon, groups0, experts0)
     inp = TripleNorm.apply(*inp.chunk(3, 1), norm_power)
-    inp = moe_check(inp, w2, training, jitter_epsilon, feature_shuffle2, groups2, experts2)
-    return input_cache, cumsum_cache, inp
+    inp = conv(inp, w1, bottleneck_group, True)
+    inp = TripleNorm.apply(*inp.chunk(3, 1), norm_power)
+    return moe_check(inp, w2, training, jitter_epsilon, groups2, experts2)
 
 
 def conv_weight(in_features: int, out_features: int, kernel_size: int, groups: int, std: float):
@@ -255,12 +230,18 @@ class LinearAttention(torch.nn.Module):
         pos_embd = torch.arange(0, ctx.model.sequence_length).unsqueeze(0) + 1
         self.register_buffer("divisor", pos_embd.unsqueeze(0).to(torch.float).to(ctx.model.device))
 
-        cell = LinearAttentionCell(self, ctx, 1)
+        ff = FeedForward(self, ctx, 1, 1)
+        attn = FFTAttention(self, ctx, 1)
         self.stem = revlib.ReversibleSequential(*[c
-                                                  for i in range(1, 1 + ctx.model.depth)
-                                                  for c in [cell.momentum((1 - ctx.model.momentumnet_beta) /
-                                                                          ctx.model.momentumnet_beta ** i, not ctx.model.weight_sharing),
-                                                            MomentumNetSide(ctx.model.momentumnet_beta ** i)]],
+                                                  for i in range(1, 1 + ctx.model.depth * 2, 2)
+                                                  for c in [ff.momentum((1 - ctx.model.momentumnet_beta) /
+                                                                        ctx.model.momentumnet_beta ** i,
+                                                                        not ctx.model.weight_sharing),
+                                                            MomentumNetSide(ctx.model.momentumnet_beta ** i),
+                                                            attn.momentum((1 - ctx.model.momentumnet_beta) /
+                                                                          ctx.model.momentumnet_beta ** (i + 1),
+                                                                          not ctx.model.weight_sharing),
+                                                            MomentumNetSide(ctx.model.momentumnet_beta ** (i + 1))]],
                                                 target_device=ctx.model.device)
         self.output = torch.nn.Conv1d(ctx.model.features * 2, ctx.dataset.classes, (1,)).to(ctx.model.device)
         torch.nn.init.zeros_(self.output.weight.data)
@@ -270,7 +251,7 @@ class LinearAttention(torch.nn.Module):
 
     def reset_cache(self):
         for mod in self.stem.modules():
-            if isinstance(mod, LinearAttentionCell):
+            if isinstance(mod, FeedForward):
                 mod.reset_cache()
 
 
@@ -300,9 +281,9 @@ def get_moe_param(in_features: int, out_features: int, groups: int, experts: int
     return [torch.nn.Parameter(conv_weight(in_features, out_features, 1, groups, std))]
 
 
-class LinearAttentionCell(torch.nn.Module):
-    def __init__(self, base: LinearAttention, ctx: Context, init_scale: float):
-        super(LinearAttentionCell, self).__init__()
+class FeedForward(torch.nn.Module):
+    def __init__(self, base: LinearAttention, ctx: Context, init_scale: float, feature_factor: float):
+        super(FeedForward, self).__init__()
         self.divisor = lambda: base.divisor
         self.init_scale = init_scale
         self.caching = ctx.eval.cache
@@ -316,50 +297,38 @@ class LinearAttentionCell(torch.nn.Module):
         self.jitter_epsilon = ctx.model.moe_jitter_epsilon
         self.expert_chunks = ctx.model.expert_chunks
         intermediate = int(ctx.model.features * ctx.model.feed_forward_intermediate_factor)
-        self.w0 = torch.nn.ParameterList(get_moe_param(ctx.model.features, intermediate * 3, self.groups0,
-                                                       self.experts0, self.expert_chunks, ctx.model.activation_std))
+        self.w0 = torch.nn.ParameterList(get_moe_param(ctx.model.features * feature_factor, intermediate * 3,
+                                                       self.groups0, self.experts0, self.expert_chunks,
+                                                       ctx.model.activation_std))
         self.w1 = conv_weight(intermediate, intermediate * 3, ctx.model.conv_kernel_size, ctx.model.bottleneck_group,
                               ctx.model.activation_std)
-        self.w2 = torch.nn.ParameterList(get_moe_param(intermediate, ctx.model.features, self.groups2,
+        self.w2 = torch.nn.ParameterList(get_moe_param(intermediate, ctx.model.features * feature_factor, self.groups2,
                                                        self.experts2, self.expert_chunks, 1))
         self.idx: int = 0
-        self._input_cache = torch.zeros([])
-        self._cumsum_cache = torch.zeros([])
-        if ctx.model.feature_shuffle:
-            self.register_buffer("feature_shuffle0", torch.argsort(torch.randn(ctx.model.features)).view(1, -1, 1))
-            self.register_buffer("feature_shuffle2", torch.argsort(torch.randn(intermediate)).view(1, -1, 1))
-        else:
-            self.feature_shuffle0 = None
-            self.feature_shuffle2 = None
 
-    def reset_cache(self):
-        self._cumsum_cache = torch.zeros([])
-        self._input_cache = torch.zeros([])
-        self.idx = 0
+    def _ff(self, inp: torch.Tensor) -> torch.Tensor:
+        return linear_attention(inp, self.w0, self.groups0, self.experts0, self.w1, self.w2, self.groups2,
+                                self.experts2,
+                                self.bottleneck_group, self.training, self.norm_power, self.jitter_epsilon)
 
     def forward(self, inp: torch.Tensor) -> torch.Tensor:
-        if self.training:
-            div = self.divisor()
-        elif self.caching:
-            self.idx += inp.size(2)
-            div = torch.LongTensor([self.idx]).to(inp.device)
-        else:
-            self.idx = inp.size(2)
-            div = torch.arange(self.idx, device=inp.device).view(1, 1, -1) + 1
-        self._input_cache, self._cumsum_cache, out = linear_attention(inp, div,
-                                                                      self.w0, self.feature_shuffle0, self.groups0,
-                                                                      self.experts0,
-                                                                      self.w1,
-                                                                      self.w2, self.feature_shuffle2, self.groups2,
-                                                                      self.experts2, self._input_cache,
-                                                                      self._cumsum_cache, self.bottleneck_group,
-                                                                      self.training, self.caching, self.idx,
-                                                                      self.norm_power, self.jitter_epsilon
-                                                                      )
-        out = out * self.init_scale
-        return out
+        return self._ff(inp) * self.init_scale
 
     def momentum(self, init_scale: float, deep: bool):
         out = copy.deepcopy(self) if deep else copy.copy(self)
         out.init_scale = init_scale
         return out
+
+
+class FFTAttention(FeedForward):
+    def __init__(self, base: LinearAttention, ctx: Context, init_scale: float):
+        super(FFTAttention, self).__init__(base, ctx, init_scale, 2)
+
+    def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        batch, features, sequence = inp.size()
+        out = torch.view_as_real(torch.fft.rfft(inp, 2 * sequence))
+        out = out.transpose(2, 3).reshape(batch, features * 2, sequence + 1)
+        out = self._ff(out)
+        out = out.view(batch, features, 2, sequence + 1).transpose(2, 3)
+        out = torch.view_as_complex(out)
+        return torch.fft.irfft(out, 2 * sequence)[:, :, :sequence]

--- a/src/model.py
+++ b/src/model.py
@@ -4,7 +4,6 @@ import typing
 import numpy as np
 import revlib
 import torch
-import torch.nn.functional
 import torch.utils.data
 from torch.nn import functional as F
 from torch.optim.lr_scheduler import LambdaLR

--- a/src/model.py
+++ b/src/model.py
@@ -152,20 +152,19 @@ class Trainer(torch.nn.Module):
         self.model = torch.jit.trace(model, data) if data else model
         self.optimizer = build_optimizer(ctx, self.model.parameters())
         self.scheduler = OneCycleLR(self.optimizer,
-                                    ctx.optimizer.one_cycle.cycle_min_lr,
-                                    ctx.optimizer.one_cycle.cycle_max_lr,
-                                    ctx.optimizer.one_cycle.decay_lr_rate,
-                                    ctx.optimizer.one_cycle.cycle_first_step_size,
-                                    ctx.optimizer.one_cycle.cycle_second_step_size,
-                                    ctx.optimizer.one_cycle.cycle_first_stair_count,
-                                    ctx.optimizer.one_cycle.cycle_second_stair_count,
-                                    ctx.optimizer.one_cycle.decay_step_size,
+                                    ctx.optimizer.one_cycle.max_lr,
+                                    ctx.optimizer.one_cycle.total_steps,
+                                    ctx.optimizer.one_cycle.epochs,
+                                    ctx.optimizer.one_cycle.steps_per_epoch,
+                                    ctx.optimizer.one_cycle.pct_start,
+                                    ctx.optimizer.one_cycle.anneal_strategy,
                                     ctx.optimizer.one_cycle.cycle_momentum,
-                                    ctx.optimizer.one_cycle.cycle_min_mom,
-                                    ctx.optimizer.one_cycle.cycle_max_mom,
-                                    ctx.optimizer.one_cycle.decay_mom_rate,
-                                    ctx.optimizer.one_cycle.last_batch_iteration)
-
+                                    ctx.optimizer.one_cycle.base_momentum,
+                                    ctx.optimizer.one_cycle.max_momentum,
+                                    ctx.optimizer.one_cycle.div_factor,
+                                    ctx.optimizer.one_cycle.final_div_factor,
+                                    ctx.optimizer.one_cycle.three_phase,
+                                    ctx.optimizer.one_cycle.last_epoch)
     @torch.no_grad()
     def _to_device_detach(self, inp: torch.Tensor) -> torch.Tensor:
         return inp.to(device=self.ctx.model.device, non_blocking=True).detach()
@@ -252,7 +251,7 @@ class LinearAttention(torch.nn.Module):
                                                                           i + 1),
                                                             MomentumNetSide(ctx.model.momentumnet_beta ** (i + 1))]],
                                                 target_device=ctx.model.device,
-                                                memory_mode=revlib.MemoryModes.autograd_graph)
+                                                memory_mode=revlib.MemoryModes.autograd_function)
         self.output = torch.nn.Conv1d(ctx.model.features * 2, ctx.dataset.classes, (1,)).to(ctx.model.device)
         torch.nn.init.zeros_(self.output.weight.data)
 

--- a/src/model.py
+++ b/src/model.py
@@ -173,7 +173,7 @@ class Trainer(torch.nn.Module):
         src = self._to_device_detach(src)
         msk = torch.rand(src.size(), dtype=torch.float32, device=src.device) > self.ctx.dataset.dropout
         out = self.model(src * msk)
-        msk = 1 - msk
+        msk = ~msk
         masked = msk.sum()
         loss = (F.cross_entropy(out, src, reduction="none") * msk).sum() / masked
         loss.backward()
@@ -338,6 +338,10 @@ class FeedForward(torch.nn.Module):
         self.idx: int = 0
         self.depth: int = 0
         self.get_last: bool = True
+
+    def __repr__(self):
+        extra = '\n  '.join([f'{name}: {param.size()}' for name, param in self.named_parameters()])
+        return f"{self._get_name()}(\n  {extra}\n)"
 
     def _cut_off(self, inp: torch.Tensor) -> torch.Tensor:
         if inp.size(2) == self.ctx.model.sequence_length:

--- a/src/model.py
+++ b/src/model.py
@@ -225,9 +225,7 @@ class MomentumNetSide(torch.nn.Module):
 class LinearAttention(torch.nn.Module):
     def __init__(self, ctx: Context):
         super(LinearAttention, self).__init__()
-        print("Enter Linear attention")
         self.embedding = torch.nn.Embedding(ctx.dataset.classes, ctx.model.features * 2).to(ctx.model.device)
-        print("EMbedding")
         orthonormal(self.embedding.weight, ctx.model.input_embedding_std * 2 ** -0.5)
 
         pos_embd = torch.arange(0, ctx.model.sequence_length).unsqueeze(0) + 1
@@ -241,7 +239,6 @@ class LinearAttention(torch.nn.Module):
                              f" following: {modules}")
         attn = attention_modules[modules.index(ctx.model.attention)](self, ctx, 1)
         self.expand_sequence = attn.get_last | ff.get_last
-        print("Attn/ff")
         self.stem = revlib.ReversibleSequential(*[c
                                                   for i in range(1, 1 + ctx.model.depth * 2, 2)
                                                   for c in [ff.momentum((1 - ctx.model.momentumnet_beta) /
@@ -255,9 +252,7 @@ class LinearAttention(torch.nn.Module):
                                                                           i + 1),
                                                             MomentumNetSide(ctx.model.momentumnet_beta ** (i + 1))]],
                                                 target_device=ctx.model.device)
-        print("Stem")
         self.output = torch.nn.Conv1d(ctx.model.features * 2, ctx.dataset.classes, (1,)).to(ctx.model.device)
-        print("Out")
         torch.nn.init.zeros_(self.output.weight.data)
 
     def forward(self, inp: torch.Tensor):

--- a/src/model.py
+++ b/src/model.py
@@ -225,7 +225,9 @@ class MomentumNetSide(torch.nn.Module):
 class LinearAttention(torch.nn.Module):
     def __init__(self, ctx: Context):
         super(LinearAttention, self).__init__()
+        print("Enter Linear attention")
         self.embedding = torch.nn.Embedding(ctx.dataset.classes, ctx.model.features * 2).to(ctx.model.device)
+        print("EMbedding")
         orthonormal(self.embedding.weight, ctx.model.input_embedding_std * 2 ** -0.5)
 
         pos_embd = torch.arange(0, ctx.model.sequence_length).unsqueeze(0) + 1
@@ -239,6 +241,7 @@ class LinearAttention(torch.nn.Module):
                              f" following: {modules}")
         attn = attention_modules[modules.index(ctx.model.attention)](self, ctx, 1)
         self.expand_sequence = attn.get_last | ff.get_last
+        print("Attn/ff")
         self.stem = revlib.ReversibleSequential(*[c
                                                   for i in range(1, 1 + ctx.model.depth * 2, 2)
                                                   for c in [ff.momentum((1 - ctx.model.momentumnet_beta) /
@@ -252,7 +255,9 @@ class LinearAttention(torch.nn.Module):
                                                                           i + 1),
                                                             MomentumNetSide(ctx.model.momentumnet_beta ** (i + 1))]],
                                                 target_device=ctx.model.device)
+        print("Stem")
         self.output = torch.nn.Conv1d(ctx.model.features * 2, ctx.dataset.classes, (1,)).to(ctx.model.device)
+        print("Out")
         torch.nn.init.zeros_(self.output.weight.data)
 
     def forward(self, inp: torch.Tensor):

--- a/src/model.py
+++ b/src/model.py
@@ -353,10 +353,13 @@ class FeedForward(torch.nn.Module):
 
         batch, features, sequence = inp.size()
         if self.get_last:
-            return torch.cat([torch.zeros((batch, features, self.ctx.model.sequence_length * self.depth)), out.size(),
+            return torch.cat([torch.zeros((batch, features, self.ctx.model.sequence_length * self.depth),
+                                          device=out.device, dtype=out.dtype), out,
                               torch.zeros((batch, features,
-                                           sequence - self.ctx.model.sequence_length * (self.depth + 1)))], 2)
-        return torch.cat([out.size(), torch.zeros((batch, features, sequence - out.size()))], 2)
+                                           sequence - self.ctx.model.sequence_length * (self.depth + 1)),
+                                          device=out.device, dtype=out.dtype)], 2)
+        return torch.cat([out, torch.zeros((batch, features, sequence - out.size(2)), device=out.device,
+                                           dtype=out.dtype)], 2)
 
     def _ff(self, inp: torch.Tensor) -> torch.Tensor:
         return linear_attention(inp, self.w0, self.groups0, self.experts0, self.w1, self.w2, self.groups2,

--- a/src/model.py
+++ b/src/model.py
@@ -263,7 +263,7 @@ class LinearAttention(torch.nn.Module):
                                                             MomentumNetSide(ctx.model.momentumnet_beta ** (i + 1))]],
                                                 target_device=ctx.model.device,
                                                 memory_mode=revlib.MemoryModes.autograd_function)
-        self.output = torch.nn.Conv1d(ctx.model.features, ctx.dataset.classes, (1,)).to(ctx.model.device)
+        self.output = torch.nn.Conv1d(ctx.model.features * 2, ctx.dataset.classes, (1,)).to(ctx.model.device)
         torch.nn.init.orthogonal_(self.output.weight.data)
 
     def forward(self, inp: torch.Tensor):

--- a/src/model.py
+++ b/src/model.py
@@ -176,7 +176,7 @@ class Trainer(torch.nn.Module):
         loss = F.cross_entropy(out, tgt)
         loss.backward()
         with torch.inference_mode():
-            return loss.detach(), (out == tgt).sum().float() / tgt.numel()
+            return loss.detach(), (torch.argmax(out, 1) == tgt).sum().float() / tgt.numel()
 
     @torch.no_grad()
     def _clip_gradient(self):

--- a/src/model.py
+++ b/src/model.py
@@ -263,7 +263,6 @@ class LinearAttention(torch.nn.Module):
             out = torch.cat([inp, torch.zeros((batch, features, sequence * len(self.stem.stem)), device=inp.device,
                                               dtype=inp.dtype)], 2)
         out = self.stem(out)
-
         if self.expand_sequence:
             batch, features, sequence = inp.size()
             inp = out.view(batch, features, -1, sequence).mean(2)

--- a/src/model.py
+++ b/src/model.py
@@ -195,7 +195,7 @@ class Trainer(torch.nn.Module):
             loss += lss
             accuracy += acc
         self._clip_gradient()
-        return loss / data[0].size(0), accuracy / data[0].size(0)
+        return loss, accuracy
 
     @torch.no_grad()
     def zero_grad(self):

--- a/src/model.py
+++ b/src/model.py
@@ -165,6 +165,7 @@ class Trainer(torch.nn.Module):
                                     ctx.optimizer.one_cycle.final_div_factor,
                                     ctx.optimizer.one_cycle.three_phase,
                                     ctx.optimizer.one_cycle.last_epoch)
+
     @torch.no_grad()
     def _to_device_detach(self, inp: torch.Tensor) -> torch.Tensor:
         return inp.to(device=self.ctx.model.device, non_blocking=True).detach()
@@ -261,12 +262,12 @@ class LinearAttention(torch.nn.Module):
             batch, features, sequence = inp.size()
             out = torch.cat([inp, torch.zeros((batch, features, sequence * len(self.stem.stem)), device=inp.device,
                                               dtype=inp.dtype)], 2)
-        out = self.output(self.stem(out))
+        out = self.stem(out)
 
         if self.expand_sequence:
             batch, features, sequence = inp.size()
-            inp = out.view(batch, features // 2, -1, sequence).mean(2)
-        return inp
+            inp = out.view(batch, features, -1, sequence).mean(2)
+        return self.output(inp)
 
     def reset_cache(self):
         for mod in self.stem.modules():

--- a/src/optimizers/build.py
+++ b/src/optimizers/build.py
@@ -1,14 +1,13 @@
 import inspect
 import typing
 
-import deepspeed.ops.adam
 import torch
 
 from src.dataclass import Context
 from src.optimizers import shampoo
 
 OWN_OPTIMIZER = {'Shampoo': shampoo.Shampoo}
-LIB_OPTIMIZER = {'DeepSpeedCPUAdam': deepspeed.ops.adam.DeepSpeedCPUAdam}
+LIB_OPTIMIZER = {}
 
 
 def build_optimizer(ctx: Context, parameters: typing.Iterable[torch.nn.Parameter]):

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -36,41 +36,56 @@ class WandbLog:
     def __init__(self, ctx: Context, steps: int):
         self.mean_loss = 0
         self.mean_max_loss = 0
+        self.mean_acc = 0
+        self.mean_max_acc = 0
         self.start_time = time.time()
         self.ctx = ctx
         self.idx = 0
         self.prev = 0
         self.steps = steps
 
-    def __call__(self, current_loss: torch.Tensor, max_loss: torch.Tensor, learning_rate: float,
+    def normalize(self, var: torch.Tensor, attribute: str) -> float:
+        attr = getattr(self, attribute)
+        curr_var = var.item() / self.ctx.log.loss_steps_per_print / self.ctx.optimizer.gradient_accumulation_steps
+        setattr(self, attribute, (attr * self.prev + curr_var * self.idx) / (self.prev + self.idx))  # LWMA
+        return curr_var
+
+    def __call__(self, current_loss: torch.Tensor, max_loss: torch.Tensor,
+                 current_acc: torch.Tensor, max_acc: torch.Tensor, learning_rate: float,
                  betas: typing.Tuple[float, float]):
-        grad_accum = self.ctx.optimizer.gradient_accumulation_steps
-        curr_loss = current_loss.item() / self.ctx.log.loss_steps_per_print / grad_accum
-        curr_max_loss = max_loss.item() / self.ctx.log.loss_steps_per_print / grad_accum
         self.idx += 1
-        self.mean_loss = (self.mean_loss * self.prev + curr_loss * self.idx) / (self.prev + self.idx)  # LWMA
-        mean_max = self.mean_max_loss = (self.mean_max_loss * self.prev + max_loss * self.idx) / (self.prev + self.idx)
+        current_loss = self.normalize(current_loss, "mean_loss")
+        current_acc = self.normalize(current_acc, "mean_acc")
+        if self.ctx.optimizer.sharpness_aware_minimization:
+            max_loss = self.normalize(max_loss, "mean_max_loss")
+            max_acc = self.normalize(max_acc, "mean_max_acc")
+        else:
+            max_loss = max_acc = self.mean_max_loss = self.mean_max_acc = None
         self.prev += self.idx
 
         rate = self.ctx.log.loss_steps_per_print * self.idx / (time.time() - self.start_time)
-        tokens_per_day = grad_accum * 3600 * 24 * rate * self.ctx.model.batch_size * self.ctx.model.sequence_length
+        tokens_per_day = 3600 * 24 * rate * self.ctx.model.batch_size * self.ctx.model.sequence_length
+        tokens_per_day *= self.ctx.optimizer.gradient_accumulation_steps
 
         pretty_print(f"[{self.idx * self.ctx.log.loss_steps_per_print:{len(str(self.steps))}d}/{self.steps}]",
-                     f"Loss: {curr_loss:7.4f} -",
+                     f"Loss: {current_loss:7.4f} -",
                      f"Mean: {self.mean_loss:7.4f} |",
+                     f"Acc: {current_acc:7.4f} -",
+                     f"Mean: {self.mean_acc:7.4f} |",
                      f"LR: {learning_rate:.6f} -",
                      f"Beta1: {betas[0]:.3f} -",
                      f"Beta2: {betas[1]:.3f} |",
                      f"Batch/s: {rate:6.3f} -",
                      f"Tokens/day: {tokens_per_day:11,.0f}")
 
-        if not self.ctx.optimizer.sharpness_aware_minimization.enabled:
-            curr_max_loss = None
-            mean_max = None
-        wandb.log({"Loss/Current": curr_loss,
+        wandb.log({"Loss/Current": current_loss,
                    "Loss/Mean": self.mean_loss,
-                   "Loss/Current Max": curr_max_loss,
-                   "Loss/Mean Max": mean_max,
+                   "Loss/Current Max": max_loss,
+                   "Loss/Mean Max": self.mean_max_loss,
+                   "Accuracy/Current": current_acc,
+                   "Accuracy/Mean": self.mean_acc,
+                   "Accuracy/Current Max": max_acc,
+                   "Accuracy/Mean Max": self.mean_max_acc,
                    "Speed/Batches per Second": rate,
                    "Speed/Tokens per Day": tokens_per_day,
                    "Optimizer/Learning Rate": learning_rate,

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -40,7 +40,6 @@ def setup_torch(seed: int):
 
 
 def get_model(ctx: Context, load_model: bool, data: typing.Optional[torch.Tensor] = None) -> Trainer:
-    pritn("Get model")
     mod = Trainer(ctx, LinearAttention(ctx).to(dtype=torch.float16 if ctx.model.float16 else torch.float),
                   data if data is None else None)
 

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -40,6 +40,7 @@ def setup_torch(seed: int):
 
 
 def get_model(ctx: Context, load_model: bool, data: typing.Optional[torch.Tensor] = None) -> Trainer:
+    pritn("Get model")
     mod = Trainer(ctx, LinearAttention(ctx).to(dtype=torch.float16 if ctx.model.float16 else torch.float),
                   data if data is None else None)
 


### PR DESCRIPTION
This PR also
* adds a new custom sum-based attention
* changes a bunch of parameter names
* changes small.yaml to integrate omnidirectional attention
* breaks up our linear attention module into one ff and one attention module
* removes DeepSpeed's broken CPUAdam
* enforces full attention while removing autoregressive attention

The idea of FFT-based attention comes from [FNet](https://arxiv.org/abs/2105.03824), [LMU](https://arxiv.org/abs/2102.11417) and [On Learning the Transformer Kernel](https://arxiv.org/abs/2110.08323), but is implemented differently to optimize the expressivity of our model.\
[OmniNet](https://arxiv.org/pdf/2103.01075.pdf) attends to all previous hidden states instead of only the current hidden state, bridging the gap between linear attention and full attention.\
A custom data loader is required as PyTorch's data loader gives CPU-OOMs, has a broken shuffling function and requires >8GiB RAM to instantiate 12 empty classes. While this wasn't the case in PyTorch 1.9, it is in 1.10 on WSL.\
As WSL cannot deallocate GPU memory, we had to support windows natively.